### PR TITLE
Find paths in refs empty maps

### DIFF
--- a/src/dag_unify/core.cljc
+++ b/src/dag_unify/core.cljc
@@ -13,8 +13,10 @@
 
 (defn unify
   "like unify!, but non-destructively copy each argument before unifying."
-  [val1 val2]
-  (unify! (copy val1) (copy val2)))
+  ([val1 val2 & vals]
+   (reduce unify! (map copy (concat [val1 val2] vals))))
+  ([val1 val2]
+   (unify! (copy val1) (copy val2))))
 
 (def ^:dynamic exception-if-cycle?
   "If true, and if unifying two DAGs would cause a cycle, thrown an exception. If false,

--- a/src/dag_unify/serialization.cljc
+++ b/src/dag_unify/serialization.cljc
@@ -54,6 +54,11 @@
               (cons path
                     (get retval input nil)))))
 
+    (and
+     (map? input)
+     (empty? input))
+    retval
+
     (map? input)
     (reduce (fn [a b] (merge-with concat a b))
             (map (fn [key]


### PR DESCRIPTION
Bug fix: in (defn find-paths-to-refs), simply return the _retval_ param
Enhancement: in (defn unify), allow more than two parameters

